### PR TITLE
fix: replace sync.Once with retryable OAuth endpoint discovery

### DIFF
--- a/providers/openshift.go
+++ b/providers/openshift.go
@@ -49,10 +49,6 @@ const (
 type OpenShiftProvider struct {
 	*ProviderData
 	useSystemTrustStore bool
-	discoveryOnce       sync.Once
-	discoveryErr        error
-	discoveredLogin     *url.URL
-	discoveredRedeem    *url.URL
 
 	// CAFiles contains paths to custom CA certificate files for TLS connections
 	// to the OpenShift OAuth server and API endpoints
@@ -61,6 +57,11 @@ type OpenShiftProvider struct {
 	// httpClientCache caches HTTP clients by CA configuration to avoid
 	// recreating clients when CA certificates haven't changed
 	httpClientCache sync.Map
+
+	// discoveryMu guards the check-then-act on LoginURL/RedeemURL during
+	// on-demand OAuth endpoint discovery, preventing concurrent goroutines
+	// from racing on the shared provider state.
+	discoveryMu sync.Mutex
 }
 
 // NewOpenShiftProvider creates a new OpenShiftProvider instance.
@@ -122,38 +123,52 @@ func NewOpenShiftProvider(p *ProviderData, cfg options.Provider) (*OpenShiftProv
 
 // GetLoginURL returns the OAuth login URL, using discovery if not configured
 func (p *OpenShiftProvider) GetLoginURL(redirectURI, state, _ string, extraParams url.Values) string {
-	// If LoginURL is not configured, try auto-discovery as a convenience
 	if p.LoginURL == nil || p.LoginURL.String() == "" {
-		logger.Printf("LoginURL not configured, attempting auto-discovery from Kubernetes API")
-		client, err := p.newOpenShiftClient()
-		if err != nil {
-			logger.Errorf("Failed to create OpenShift client for discovery: %v", err)
-			logger.Printf("Please configure --login-url manually")
-			return ""
-		}
-		p.discoveryOnce.Do(func() {
-			p.discoveredLogin, p.discoveredRedeem, p.discoveryErr = p.discoverOpenShiftOAuth(client)
-		})
-		if p.discoveryErr != nil || p.discoveredLogin == nil {
-			if p.discoveryErr != nil {
-				logger.Errorf("Failed to discover OpenShift OAuth endpoints: %v", p.discoveryErr)
+		p.discoveryMu.Lock()
+		defer p.discoveryMu.Unlock()
+		// Double-check after acquiring the lock (another goroutine may have completed discovery)
+		if p.LoginURL == nil || p.LoginURL.String() == "" {
+			logger.Printf("LoginURL not configured, attempting auto-discovery from Kubernetes API")
+			client, err := p.newOpenShiftClient()
+			if err != nil {
+				logger.Errorf("Failed to create OpenShift client for discovery: %v", err)
+				logger.Printf("Please configure --login-url manually")
+				return ""
 			}
-			logger.Printf("Please configure --login-url and --redeem-url manually")
-			return ""
-		}
-		p.LoginURL = p.discoveredLogin
-		if p.RedeemURL == nil || p.RedeemURL.String() == "" {
-			p.RedeemURL = p.discoveredRedeem
-		}
-		logger.Printf("Auto-discovered LoginURL: %s", p.LoginURL.String())
-		if p.RedeemURL != nil {
-			logger.Printf("Auto-discovered RedeemURL: %s", p.RedeemURL.String())
+			loginURL, redeemURL, err := p.discoverOpenShiftOAuth(client)
+			if err != nil {
+				logger.Errorf("Failed to discover OpenShift OAuth endpoints: %v", err)
+				logger.Printf("Please configure --login-url and --redeem-url manually")
+				return ""
+			}
+			p.LoginURL = loginURL
+			if p.RedeemURL == nil || p.RedeemURL.String() == "" {
+				p.RedeemURL = redeemURL
+			}
+			logger.Printf("Auto-discovered LoginURL: %s", p.LoginURL.String())
+			if p.RedeemURL != nil {
+				logger.Printf("Auto-discovered RedeemURL: %s", p.RedeemURL.String())
+			}
 		}
 	}
 
-	// Build the complete OAuth2 authorization URL using the standard helper
 	loginURL := makeLoginURL(p.Data(), redirectURI, state, extraParams)
 	return loginURL.String()
+}
+
+// discoverRedeemURL performs thread-safe on-demand discovery of the RedeemURL.
+func (p *OpenShiftProvider) discoverRedeemURL(client *http.Client) (*url.URL, error) {
+	p.discoveryMu.Lock()
+	defer p.discoveryMu.Unlock()
+	if p.RedeemURL != nil && p.RedeemURL.String() != "" {
+		return p.RedeemURL, nil
+	}
+	_, discoveredRedeem, err := p.discoverOpenShiftOAuth(client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover redeem URL: %v", err)
+	}
+	p.RedeemURL = discoveredRedeem
+	return discoveredRedeem, nil
 }
 
 // Redeem exchanges the authorization code for an access token
@@ -170,17 +185,11 @@ func (p *OpenShiftProvider) Redeem(ctx context.Context, redirectURL, code, codeV
 	// Get redeem URL from discovery if not configured
 	redeemURL := p.RedeemURL
 	if redeemURL == nil || redeemURL.String() == "" {
-		p.discoveryOnce.Do(func() {
-			p.discoveredLogin, p.discoveredRedeem, p.discoveryErr = p.discoverOpenShiftOAuth(client)
-		})
-		if p.discoveryErr != nil || p.discoveredRedeem == nil {
-			return nil, fmt.Errorf("failed to discover redeem URL: %v", p.discoveryErr)
+		discovered, discoveryErr := p.discoverRedeemURL(client)
+		if discoveryErr != nil {
+			return nil, discoveryErr
 		}
-		redeemURL = p.discoveredRedeem
-		// Persist for subsequent calls if not explicitly configured
-		if p.RedeemURL == nil || p.RedeemURL.String() == "" {
-			p.RedeemURL = redeemURL
-		}
+		redeemURL = discovered
 	}
 
 	params := url.Values{}

--- a/providers/openshift_test.go
+++ b/providers/openshift_test.go
@@ -2,9 +2,11 @@ package providers
 
 import (
 	"context"
+	"encoding/pem"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
 
@@ -410,6 +412,183 @@ func TestOpenShiftProviderCreateSessionFromTokenWithGroups(t *testing.T) {
 	assert.Contains(t, session.Groups, "developers")
 	assert.Contains(t, session.Groups, "viewers")
 	assert.Equal(t, 3, len(session.Groups))
+}
+
+func TestOpenShiftProviderDiscoveryRetriesAfterFailure(t *testing.T) {
+	callCount := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/oauth-authorization-server" {
+			callCount++
+			if callCount == 1 {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				w.Write([]byte("API server temporarily unavailable"))
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"authorization_endpoint": "https://oauth.example.com/authorize",
+				"token_endpoint": "https://oauth.example.com/token"
+			}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	// Point the Kubernetes service env vars to our TLS mock server
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	t.Setenv("KUBERNETES_SERVICE_HOST", serverURL.Hostname())
+	t.Setenv("KUBERNETES_SERVICE_PORT", serverURL.Port())
+
+	provider := &OpenShiftProvider{
+		ProviderData: &ProviderData{},
+	}
+
+	// Use the TLS test server's client for discovery (bypass CA validation)
+	client := server.Client()
+
+	// First call: discovery fails (503)
+	login, redeem, err := provider.discoverOpenShiftOAuth(client)
+	assert.Error(t, err, "Discovery should fail on first attempt")
+	assert.Nil(t, login)
+	assert.Nil(t, redeem)
+
+	// Second call: discovery succeeds (server returns 200)
+	login, redeem, err = provider.discoverOpenShiftOAuth(client)
+	assert.NoError(t, err, "Discovery should succeed on second attempt")
+	assert.NotNil(t, login)
+	assert.NotNil(t, redeem)
+	assert.Equal(t, "https://oauth.example.com/authorize", login.String())
+	assert.Equal(t, "https://oauth.example.com/token", redeem.String())
+}
+
+func TestOpenShiftProviderGetLoginURLRetriesAfterFailure(t *testing.T) {
+	callCount := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/oauth-authorization-server" {
+			callCount++
+			if callCount == 1 {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				w.Write([]byte("API server temporarily unavailable"))
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"authorization_endpoint": "https://oauth.example.com/authorize",
+				"token_endpoint": "https://oauth.example.com/token"
+			}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	t.Setenv("KUBERNETES_SERVICE_HOST", serverURL.Hostname())
+	t.Setenv("KUBERNETES_SERVICE_PORT", serverURL.Port())
+
+	caFile := writeTestServerCA(t, server)
+
+	provider := &OpenShiftProvider{
+		ProviderData: &ProviderData{},
+		CAFiles:      []string{caFile},
+	}
+
+	// First call: discovery fails (503), GetLoginURL returns empty
+	result := provider.GetLoginURL("http://localhost/callback", "state123", "", url.Values{})
+	assert.Empty(t, result, "GetLoginURL should return empty when discovery fails")
+	assert.Nil(t, provider.LoginURL, "LoginURL should not be set after failure")
+
+	// Second call: discovery succeeds, GetLoginURL returns a valid URL
+	result = provider.GetLoginURL("http://localhost/callback", "state123", "", url.Values{})
+	assert.NotEmpty(t, result, "GetLoginURL should return a URL after discovery succeeds on retry")
+	assert.NotNil(t, provider.LoginURL, "LoginURL should be set after successful discovery")
+	assert.Equal(t, "https://oauth.example.com/authorize", provider.LoginURL.String())
+	assert.NotNil(t, provider.RedeemURL, "RedeemURL should be set after successful discovery")
+	assert.Equal(t, "https://oauth.example.com/token", provider.RedeemURL.String())
+
+	// Third call: should use cached LoginURL (no new discovery call)
+	previousCallCount := callCount
+	result = provider.GetLoginURL("http://localhost/callback", "state123", "", url.Values{})
+	assert.NotEmpty(t, result)
+	assert.Equal(t, previousCallCount, callCount, "No additional discovery calls should be made after success")
+}
+
+func TestOpenShiftProviderRedeemRetriesDiscoveryAfterFailure(t *testing.T) {
+	callCount := 0
+	var serverAddr string
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			callCount++
+			if callCount == 1 {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				w.Write([]byte("API server temporarily unavailable"))
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"authorization_endpoint": "` + serverAddr + `/oauth/authorize",
+				"token_endpoint": "` + serverAddr + `/oauth/token"
+			}`))
+		case "/oauth/token":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"access_token": "test-token"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	serverAddr = server.URL
+
+	parsedURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	t.Setenv("KUBERNETES_SERVICE_HOST", parsedURL.Hostname())
+	t.Setenv("KUBERNETES_SERVICE_PORT", parsedURL.Port())
+
+	caFile := writeTestServerCA(t, server)
+
+	provider := &OpenShiftProvider{
+		ProviderData: &ProviderData{
+			ClientID:     "test-client",
+			ClientSecret: "test-secret",
+		},
+		CAFiles: []string{caFile},
+	}
+
+	// First call: discovery fails
+	_, err = provider.Redeem(context.Background(), "http://localhost/callback", "code123", "")
+	assert.Error(t, err, "Redeem should fail when discovery fails")
+	assert.Contains(t, err.Error(), "failed to discover redeem URL")
+
+	// Second call: discovery succeeds, token exchange works
+	session, err := provider.Redeem(context.Background(), "http://localhost/callback", "code123", "")
+	assert.NoError(t, err, "Redeem should succeed after discovery recovers")
+	assert.NotNil(t, session)
+	assert.Equal(t, "test-token", session.AccessToken)
+}
+
+// writeTestServerCA writes the httptest.TLSServer's CA certificate to a temp file
+// and returns the file path. The caller should defer os.Remove(path).
+func writeTestServerCA(t *testing.T, server *httptest.Server) string {
+	t.Helper()
+	cert := server.Certificate()
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: cert.Raw,
+	})
+	f, err := os.CreateTemp(t.TempDir(), "test-ca-*.pem")
+	require.NoError(t, err)
+	_, err = f.Write(certPEM)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	return f.Name()
 }
 
 // Helper function to test cache key formatting


### PR DESCRIPTION
sync.Once caused permanent auth failures when the kube-apiserver was briefly unavailable during discovery. Now discoverOpenShiftOAuth is called on-demand (matching openshift/oauth-proxy behavior), allowing natural retry on the next login attempt once the API server recovers.

Resolves: RHOAIENG-67051

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
