### PR TITLE
Update Go version to 1.26 and fix linting issues.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## Changes since v7.11.0
 
-- Upgraded Go toolchain from 1.24 to 1.25.3
+- Upgraded Go toolchain from 1.25.3 to 1.26
 
 # V7.11.0
 

--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -8,7 +8,7 @@ ARG VERSION
 # For FIPS builds with CGO, we must build on the native target platform
 # because cross-compilation with CGO requires cross-compiler toolchains
 # which are not readily available in the UBI base images.
-FROM --platform=${TARGETPLATFORM} registry.access.redhat.com/ubi9/go-toolset:1.25 AS builder
+FROM --platform=${TARGETPLATFORM} registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 
 # Switch to root for build permissions
 USER root

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opendatahub-io/kube-auth-proxy/v1
 
-go 1.25.3
+go 1.26.0
 
 require (
 	github.com/Bose/minisentinel v0.0.0-20200130220412-917c5a9223bb


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Upgrade Go toolchain from 1.25.3 to 1.26.

  Changes include:
  - go.mod: Go version 1.25.3 → 1.26.0
  - Dockerfile.redhat: ubi9/go-toolset:1.25 → ubi9/go-toolset:1.26
  - CHANGELOG.md: Updated toolchain version entry

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## How Has This Been Tested?

  - golangci-lint returns 0 issues
  - go test passes all tests across all packages

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

  - [x] My change requires a change to the documentation or CHANGELOG.
  - [x] I have updated the documentation/CHANGELOG accordingly.
  - [x] I have created a feature (non-master) branch for my PR.
  - [ ] I have written tests for my code changes.

