### PR TITLE
fix: remove extra nil argument from NewOAuthProxy calls in oauthproxy_test.go

### DIFF
--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -3537,7 +3537,7 @@ func TestOAuthCallbackMissingCSRFRedirectsToSignIn(t *testing.T) {
 	// opts.DisableRedirectOnCSRFError not set → false → redirect on CSRF failure (default)
 	require.NoError(t, validation.Validate(opts))
 
-	proxy, err := NewOAuthProxy(opts, func(string) bool { return true }, nil)
+	proxy, err := NewOAuthProxy(opts, func(string) bool { return true })
 	require.NoError(t, err)
 
 	// Valid state format: "nonce:redirect". Redirect "/" is allowed. No CSRF cookie.
@@ -3566,7 +3566,7 @@ func TestOAuthCallbackMissingCSRFReturns403WhenRedirectDisabled(t *testing.T) {
 	opts.DisableRedirectOnCSRFError = true
 	require.NoError(t, validation.Validate(opts))
 
-	proxy, err := NewOAuthProxy(opts, func(string) bool { return true }, nil)
+	proxy, err := NewOAuthProxy(opts, func(string) bool { return true })
 	require.NoError(t, err)
 
 	state := "s2LEyNaz5kZdULSx3d9jmupR1rR5mzhg:/"
@@ -3586,7 +3586,7 @@ func TestIsOIDCProviderWithEndSessionURL(t *testing.T) {
 	opts := baseTestOptions()
 	require.NoError(t, validation.Validate(opts))
 
-	proxy, err := NewOAuthProxy(opts, func(string) bool { return true }, nil)
+	proxy, err := NewOAuthProxy(opts, func(string) bool { return true })
 	require.NoError(t, err)
 
 	endSessionURL, _ := url.Parse("https://login.microsoftonline.com/tenant/oauth2/v2.0/logout")
@@ -3599,7 +3599,7 @@ func TestIsOIDCProviderWithoutEndSessionURL(t *testing.T) {
 	opts := baseTestOptions()
 	require.NoError(t, validation.Validate(opts))
 
-	proxy, err := NewOAuthProxy(opts, func(string) bool { return true }, nil)
+	proxy, err := NewOAuthProxy(opts, func(string) bool { return true })
 	require.NoError(t, err)
 
 	proxy.provider.Data().EndSessionURL = nil
@@ -3611,7 +3611,7 @@ func TestGetLogoutURLReturnsEndSessionURL(t *testing.T) {
 	opts := baseTestOptions()
 	require.NoError(t, validation.Validate(opts))
 
-	proxy, err := NewOAuthProxy(opts, func(string) bool { return true }, nil)
+	proxy, err := NewOAuthProxy(opts, func(string) bool { return true })
 	require.NoError(t, err)
 
 	expected := "https://login.microsoftonline.com/tenant/oauth2/v2.0/logout"
@@ -3625,7 +3625,7 @@ func TestGetLogoutURLReturnsEmptyWhenNil(t *testing.T) {
 	opts := baseTestOptions()
 	require.NoError(t, validation.Validate(opts))
 
-	proxy, err := NewOAuthProxy(opts, func(string) bool { return true }, nil)
+	proxy, err := NewOAuthProxy(opts, func(string) bool { return true })
 	require.NoError(t, err)
 
 	proxy.provider.Data().EndSessionURL = nil
@@ -3637,7 +3637,7 @@ func TestSignOutOIDCClearsCookieAndRedirectsToIdP(t *testing.T) {
 	opts := baseTestOptions()
 	require.NoError(t, validation.Validate(opts))
 
-	proxy, err := NewOAuthProxy(opts, func(string) bool { return true }, nil)
+	proxy, err := NewOAuthProxy(opts, func(string) bool { return true })
 	require.NoError(t, err)
 
 	endSessionURL, _ := url.Parse("https://login.microsoftonline.com/tenant/oauth2/v2.0/logout")
@@ -3659,7 +3659,7 @@ func TestSignOutNonOIDCClearsCookieDirectly(t *testing.T) {
 	opts := baseTestOptions()
 	require.NoError(t, validation.Validate(opts))
 
-	proxy, err := NewOAuthProxy(opts, func(string) bool { return true }, nil)
+	proxy, err := NewOAuthProxy(opts, func(string) bool { return true })
 	require.NoError(t, err)
 
 	proxy.provider.Data().EndSessionURL = nil
@@ -3676,7 +3676,7 @@ func TestDeleteOAuthAccessTokenSkipsForNonOpenShiftProvider(t *testing.T) {
 	opts := baseTestOptions()
 	require.NoError(t, validation.Validate(opts))
 
-	proxy, err := NewOAuthProxy(opts, func(string) bool { return true }, nil)
+	proxy, err := NewOAuthProxy(opts, func(string) bool { return true })
 	require.NoError(t, err)
 
 	// Default test provider is not OpenShift, so this should be a no-op
@@ -3689,7 +3689,7 @@ func TestDeleteOAuthAccessTokenSkipsWhenAccessTokenEmpty(t *testing.T) {
 	opts := baseTestOptions()
 	require.NoError(t, validation.Validate(opts))
 
-	proxy, err := NewOAuthProxy(opts, func(string) bool { return true }, nil)
+	proxy, err := NewOAuthProxy(opts, func(string) bool { return true })
 	require.NoError(t, err)
 
 	proxy.deleteOAuthAccessToken(&sessions.SessionState{


### PR DESCRIPTION
## Description

`NewOAuthProxy` function signature accepts 2 parameters:

```go
func NewOAuthProxy(opts *options.Options, validator func(string) bool) (*OAuthProxy, error)
```

However, 10 test functions in `oauthproxy_test.go` were calling it with 3 arguments (extra `nil`):

```go
// Before (broken)
proxy, err := NewOAuthProxy(opts, func(string) bool { return true }, nil)

// After (fixed)
proxy, err := NewOAuthProxy(opts, func(string) bool { return true })
```

This caused a `typecheck` build failure during `golangci-lint` and `go test`, blocking CI on the `rhoai-3.3` branch.

### Affected tests (all 10):
- `TestOAuthCallbackMissingCSRFRedirectsToSignIn`
- `TestOAuthCallbackMissingCSRFReturns403WhenRedirectDisabled`
- `TestIsOIDCProviderWithEndSessionURL`
- `TestIsOIDCProviderWithoutEndSessionURL`
- `TestGetLogoutURLReturnsEndSessionURL`
- `TestGetLogoutURLReturnsEmptyWhenNil`
- `TestSignOutOIDCClearsCookieAndRedirectsToIdP`
- `TestSignOutNonOIDCClearsCookieDirectly`
- `TestDeleteOAuthAccessTokenSkipsForNonOpenShiftProvider`
- `TestDeleteOAuthAccessTokenSkipsWhenAccessTokenEmpty`

## Motivation and Context

CI `build` job on `rhoai-3.3` PRs fails at the Lint step with:

```
./oauthproxy_test.go:3540:71: too many arguments in call to NewOAuthProxy
    have (*options.Options, func(string) bool, nil)
    want (*options.Options, func(string) bool)
```

This blocks all PRs targeting `rhoai-3.3`, including CVE fix PRs.

## How Has This Been Tested?

- [x] `make build` — compiles successfully
- [x] `make verify-generate` — code generation up to date
- [x] `golangci-lint run` (v2.6.2, CI-pinned version) — 0 issues
- [x] All 10 affected tests pass:
  ```
  go test -v -race -run "TestOAuthCallback|TestIsOIDCProvider|TestGetLogoutURL|TestSignOut|TestDeleteOAuthAccessToken" .
  --- PASS: TestOAuthCallbackMissingCSRFRedirectsToSignIn
  --- PASS: TestOAuthCallbackMissingCSRFReturns403WhenRedirectDisabled
  --- PASS: TestIsOIDCProviderWithEndSessionURL
  --- PASS: TestIsOIDCProviderWithoutEndSessionURL
  --- PASS: TestGetLogoutURLReturnsEndSessionURL
  --- PASS: TestGetLogoutURLReturnsEmptyWhenNil
  --- PASS: TestSignOutOIDCClearsCookieAndRedirectsToIdP
  --- PASS: TestSignOutNonOIDCClearsCookieDirectly
  --- PASS: TestDeleteOAuthAccessTokenSkipsForNonOpenShiftProvider
  --- PASS: TestDeleteOAuthAccessTokenSkipsWhenAccessTokenEmpty
  PASS
  ```

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.