### PR TITLE
fix(deps): update go-toolset from 1.25 to 1.26 [rhoai-3.3]

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -6,7 +6,7 @@ ARG VERSION
 #  cache sharing of the go mod download step.
 # Go cross compilation is also faster than emulation the go compilation across
 #  multiple platforms.
-FROM --platform=${BUILDPLATFORM} registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:90a36bc2013b3fcb28e2a4b082c9b895d7c2c679e58b95aed9721970f3339d0e AS builder
+FROM --platform=${BUILDPLATFORM} registry.access.redhat.com/ubi9/go-toolset:1.26@sha256:dcddb73f4f50e4f19a5442ac7f78203491c49e2cc47ccc9af1926efc5eaf720b AS builder
 
 # Switch to root for build permissions
 USER root

--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -8,7 +8,7 @@ ARG VERSION
 # For FIPS builds with CGO, we must build on the native target platform
 # because cross-compilation with CGO requires cross-compiler toolchains
 # which are not readily available in the UBI base images.
-FROM --platform=${TARGETPLATFORM} registry.access.redhat.com/ubi9/go-toolset:1.25 AS builder
+FROM --platform=${TARGETPLATFORM} registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 
 # Switch to root for build permissions
 USER root


### PR DESCRIPTION
## Summary
- Update go-toolset builder image from 1.25 to 1.26
- `Dockerfile.konflux` pinned to `sha256:dcddb73f4f50e4f19a5442ac7f78203491c49e2cc47ccc9af1926efc5eaf720b`
- `Dockerfile.redhat` updated to tag `1.26` (no digest, matching existing pattern)

## Validation
- [x] `make lint` — 0 issues
- [x] `make test` — all passing
- [x] `make build` — compiles successfully