### PR TITLE
Migrate runtime base image to PQC variant for main

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -56,7 +56,7 @@ RUN case ${TARGETPLATFORM} in \
 
 
 # Copy binary to FIPS-compliant runtime image
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:580752f96d36c4132bffd30f9c34865bf4bd87f6aa161c969d117f21732e50f7
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc@sha256:8a842ac769de709143e4edeace516f2008dfdc431b64670ad3353fa323b44736
 # Reload version
 ARG VERSION
 


### PR DESCRIPTION
## Summary

This PR migrates the runtime base image from `registry.access.redhat.com/ubi9/ubi-minimal` to `registry.redhat.io/ubi9/ubi-minimal-pqc@sha256:8a842ac769de709143e4edeace516f2008dfdc431b64670ad3353fa323b44736` for RHOAI $BRANCH.

## Changes

- Updated runtime `FROM` statements in Dockerfiles
- Updated `ARG` variable default values where applicable
- Preserved existing tags and digests

## Rationale

The PQC (Post-Quantum Cryptography) variant provides enhanced cryptographic security for future-proofing against quantum computing threats.

## Testing

- [ ] Verify builds complete successfully
- [ ] Verify runtime functionality unchanged
- [ ] Verify PQC libraries are present

🤖 Generated with automation script